### PR TITLE
Updates to connector-c to include ssl but not make it the default connection type

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -10,6 +10,9 @@ cmake %CMAKE_ARGS% ^
       -DCMAKE_PREFIX_PATH=%LIBRARY_PREFIX% ^
       -DINSTALL_DOCREADMEDIR_STANDALONE="%cd%/junk" ^
       -DINSTALL_DOCDIR="%cd%/junk" ^
+      -DWITH_SSL=ON ^
+      -DAUTH_GSSAPI=ON ^
+      -DDEFAULT_SSL_VERIFY_SERVER_CERT=DYNAMIC ^
       ..
 
 cmake --build . --config RelWithDebInfo -j

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -11,6 +11,7 @@ cmake %CMAKE_ARGS% ^
       -DINSTALL_DOCREADMEDIR_STANDALONE="%cd%/junk" ^
       -DINSTALL_DOCDIR="%cd%/junk" ^
       -DWITH_SSL=ON ^
+      -DDEFAULT_SSL_VERIFY_SERVER_CERT=OFF ^
       -DAUTH_GSSAPI=ON ^
       -DDEFAULT_SSL_VERIFY_SERVER_CERT=DYNAMIC ^
       ..
@@ -18,8 +19,8 @@ cmake %CMAKE_ARGS% ^
 cmake --build . --config RelWithDebInfo -j
 
 if errorlevel 1 exit 1
-ctest --rerun-faild --output-on-failure --test-dir %SRC_DIR%\build\unittest\libmariadb
-ctest --rerun-faild --output-on-failure --test-dir %SRC_DIR%\build\unittest\mytap
+ctest --rerun-failed --output-on-failure --test-dir %SRC_DIR%\build\unittest\libmariadb
+ctest --rerun-failed --output-on-failure --test-dir %SRC_DIR%\build\unittest\mytap
 
 cmake --install .
 if errorlevel 1 exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -16,6 +16,8 @@ if [[ "${target_platform}" == *"osx"* ]]; then
         -DWITH_EXTERNAL_ZLIB=ON \
         -DWITH_ZLIB=system \
         -DCMAKE_BUILD_TYPE=Release \
+        -DWITH_SSL=ON \
+        -DDEFAULT_SSL_VERIFY_SERVER_CERT=OFF \
         -DCMAKE_INSTALL_PREFIX=${PREFIX} \
         ..
 
@@ -24,13 +26,15 @@ if [[ "${target_platform}" == *"osx"* ]]; then
 elif [[ "${target_platform}" == *"linux"* ]]; then
     cmake ${CMAKE_ARGS} \
         -DCMAKE_BUILD_TYPE=Release \
+        -DWITH_SSL=ON \
+        -DDEFAULT_SSL_VERIFY_SERVER_CERT=OFF \
         -DCMAKE_INSTALL_PREFIX=${PREFIX} \
         ..
 fi
 
 cmake --build . --config RelWithDebInfo -j --target install
 
-ctest --rerun-faild --output-on-failure --test-dir $SRC_DIR/build/unittest/libmariadb
-ctest --rerun-faild --output-on-failure --test-dir $SRC_DIR/build/unittest/mytap
+ctest --rerun-failed --output-on-failure --test-dir $SRC_DIR/build/unittest/libmariadb
+ctest --rerun-failed --output-on-failure --test-dir $SRC_DIR/build/unittest/mytap
 
 cmake --install . --config RelWithDebInfo --prefix ${PREFIX}

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -28,7 +28,7 @@ elif [[ "${target_platform}" == *"linux"* ]]; then
         ..
 fi
 
-cmake --build . --config RelWithDebInfo -j
+cmake --build . --config RelWithDebInfo -j --target install
 
 ctest --rerun-faild --output-on-failure --test-dir $SRC_DIR/build/unittest/libmariadb
 ctest --rerun-faild --output-on-failure --test-dir $SRC_DIR/build/unittest/mytap

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "mariadb-connector-c" %}
-{% set version = "3.4.0" %}
+{% set version = "3.1.24" %}
 
 package:
   name: {{ name|lower }}
@@ -7,12 +7,10 @@ package:
 
 source:
   url: https://github.com/mariadb-corporation/mariadb-connector-c/archive/v{{ version }}.tar.gz
-  sha256: 23efc2da9c50d71dc0bb4f25c07f9437d5b8e2b0cbd529091a83d00ccf3f6d20
+  sha256: 547831c776b73ef3ae1b22b82cb7d47858c7190a7617fe530a5175e995a13ce5
 
 build:
-  number: 2
-  script:
-    - export PKG_CONFIG_PATH=$PREFIX/lib/pkgconfig  # [ppc64le]
+  number: 0
 
 requirements:
   build:
@@ -27,7 +25,7 @@ requirements:
     - zstd
     - krb5  # [not win]
     - libcurl
-    - openssl  # [not win]
+    - openssl
     - setuptools_dso  # [not win]
     - python-kerberos  # [not win]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "mariadb-connector-c" %}
-{% set version = "3.3.10" %}
+{% set version = "3.4.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,10 +7,10 @@ package:
 
 source:
   url: https://github.com/mariadb-corporation/mariadb-connector-c/archive/v{{ version }}.tar.gz
-  sha256: 0a79088af2fbde4dbe6655dbc51bbb272b606c0d9116745697e08879e70198a7
+  sha256: 23efc2da9c50d71dc0bb4f25c07f9437d5b8e2b0cbd529091a83d00ccf3f6d20
 
 build:
-  number: 1
+  number: 4
 
 requirements:
   build:
@@ -36,7 +36,8 @@ test:
 
 about:
   home: https://github.com/mariadb-corporation/mariadb-connector-c/
-  summary: 'Simple, fast, extensible JSON encoder/decoder for Python'
+  summary: |
+    MariaDB Connector/C is used to connect applications developed in C/C++ to MariaDB and MySQL databases.The client library is LGPL licensed. 
   description: |
     MariaDB Connector/C is used to connect applications developed in C/C++ to MariaDB and MySQL databases.The client library is LGPL licensed. 
   license: LGPL-2.1-or-later

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "mariadb-connector-c" %}
-{% set version = "3.1.24" %}
+{% set version = "3.3.10" %}
 
 package:
   name: {{ name|lower }}
@@ -7,10 +7,10 @@ package:
 
 source:
   url: https://github.com/mariadb-corporation/mariadb-connector-c/archive/v{{ version }}.tar.gz
-  sha256: 547831c776b73ef3ae1b22b82cb7d47858c7190a7617fe530a5175e995a13ce5
+  sha256: 0a79088af2fbde4dbe6655dbc51bbb272b606c0d9116745697e08879e70198a7
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
